### PR TITLE
chore: add missing dependencies

### DIFF
--- a/packages/nx-heroku/.eslintrc.json
+++ b/packages/nx-heroku/.eslintrc.json
@@ -20,6 +20,23 @@
       "rules": {
         "@nx/nx-plugin-checks": "error"
       }
+    },
+    {
+      "files": ["./package.json", "./project.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "buildTargets": ["build"],
+            "checkMissingDependencies": true,
+            "checkObsoleteDependencies": true,
+            "checkVersionMismatches": true,
+            "includeTransitiveDependencies": true,
+            "ignoredDependencies": []
+          }
+        ]
+      }
     }
   ]
 }

--- a/packages/nx-heroku/package.json
+++ b/packages/nx-heroku/package.json
@@ -4,5 +4,18 @@
   "main": "src/index.js",
   "license": "MIT",
   "generators": "./generators.json",
-  "executors": "./executors.json"
+  "executors": "./executors.json",
+  "dependencies": {
+    "@nx/devkit": "18.0.8",
+    "@nx/plugin": "18.0.8",
+    "axios": "1.6.7",
+    "dotenv-expand": "^10.0.0",
+    "lodash": "^4.17.21",
+    "minimatch": "3.1.2",
+    "nx": "18.0.8",
+    "reflect-metadata": "^0.1.13",
+    "tslib": "^2.3.0",
+    "typedi": "^0.10.0",
+    "validator": "^13.9.0"
+  }
 }


### PR DESCRIPTION
Package.json was not generated by `@nx/js:tsc`. 

- Configure `@nx/dependency-checks` ESLInt rule 
- Regenerate package.json